### PR TITLE
fix(discord): Standardize all Discord IDs to string type

### DIFF
--- a/libs/agno/agno/tools/discord.py
+++ b/libs/agno/agno/tools/discord.py
@@ -51,12 +51,12 @@ class DiscordTools(Toolkit):
         response.raise_for_status()
         return response.json() if response.text else {}
 
-    def send_message(self, channel_id: int, message: str) -> str:
+    def send_message(self, channel_id: str, message: str) -> str:
         """
         Send a message to a Discord channel.
 
         Args:
-            channel_id (int): The ID of the channel to send the message to.
+            channel_id (str): The ID of the channel to send the message to.
             message (str): The text of the message to send.
 
         Returns:
@@ -70,12 +70,12 @@ class DiscordTools(Toolkit):
             logger.error(f"Error sending message: {e}")
             return f"Error sending message: {str(e)}"
 
-    def get_channel_info(self, channel_id: int) -> str:
+    def get_channel_info(self, channel_id: str) -> str:
         """
         Get information about a Discord channel.
 
         Args:
-            channel_id (int): The ID of the channel to get information about.
+            channel_id (str): The ID of the channel to get information about.
 
         Returns:
             str: A JSON string containing the channel information.
@@ -87,12 +87,12 @@ class DiscordTools(Toolkit):
             logger.error(f"Error getting channel info: {e}")
             return f"Error getting channel info: {str(e)}"
 
-    def list_channels(self, guild_id: int) -> str:
+    def list_channels(self, guild_id: str) -> str:
         """
         List all channels in a Discord server.
 
         Args:
-            guild_id (int): The ID of the server to list channels from.
+            guild_id (str): The ID of the server to list channels from.
 
         Returns:
             str: A JSON string containing the list of channels.
@@ -104,12 +104,12 @@ class DiscordTools(Toolkit):
             logger.error(f"Error listing channels: {e}")
             return f"Error listing channels: {str(e)}"
 
-    def get_channel_messages(self, channel_id: int, limit: int = 100) -> str:
+    def get_channel_messages(self, channel_id: str, limit: int = 100) -> str:
         """
         Get the message history of a Discord channel.
 
         Args:
-            channel_id (int): The ID of the channel to fetch messages from.
+            channel_id (str): The ID of the channel to fetch messages from.
             limit (int): The maximum number of messages to fetch. Defaults to 100.
 
         Returns:
@@ -122,13 +122,13 @@ class DiscordTools(Toolkit):
             logger.error(f"Error getting messages: {e}")
             return f"Error getting messages: {str(e)}"
 
-    def delete_message(self, channel_id: int, message_id: int) -> str:
+    def delete_message(self, channel_id: str, message_id: str) -> str:
         """
         Delete a message from a Discord channel.
 
         Args:
-            channel_id (int): The ID of the channel containing the message.
-            message_id (int): The ID of the message to delete.
+            channel_id (str): The ID of the channel containing the message.
+            message_id (str): The ID of the message to delete.
 
         Returns:
             str: A success message or error message.


### PR DESCRIPTION
## Summary

Discord IDs (Snowflakes), such as channel_id, user_id, message_id, etc., are large 64-bit integers that exceed the precision capacity of numeric types like float.

When defined as `int` in the function signatures, these IDs were incorrectly converted, leading to data corruption and resulting in "404 Not Found" API errors.

This change standardizes the use of `str` for all ID parameters within the DiscordTool, ensuring that the values are preserved without precision loss. This fixes the existing bug and proactively prevents future data integrity issues in the tool.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x ] Code complies with style guidelines
- [ x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ x] Self-review completed
- [ x] Documentation updated (comments, docstrings)
- [ x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ x] Tested in clean environment
- [ x] Tests added/updated (if applicable)

